### PR TITLE
Update collections path to reflect move to collections.abc for Python 3.3+

### DIFF
--- a/slytherin/collections/OrderedSet.py
+++ b/slytherin/collections/OrderedSet.py
@@ -3,7 +3,7 @@
 import collections
 
 
-class OrderedSet(collections.MutableSet):
+class OrderedSet(collections.abc.MutableSet):
 
 	def __init__(self, iterable=None):
 		self.end = end = []

--- a/slytherin/collections/__init__.py
+++ b/slytherin/collections/__init__.py
@@ -1,4 +1,4 @@
-from .Dictionary import Dictionary
+from .dictionary import Dictionary
 from .has_duplicates import has_duplicates, get_duplicates
 from .get_dict_product import get_dict_product
 from .is_iterable import is_iterable

--- a/slytherin/collections/__init__.py
+++ b/slytherin/collections/__init__.py
@@ -13,3 +13,4 @@ from .flatten import flatten
 from .sum import sum
 from .Series import Series
 from .create_grid import create_grid
+from .cross_lists import cross_lists

--- a/slytherin/collections/cross_lists.py
+++ b/slytherin/collections/cross_lists.py
@@ -1,0 +1,18 @@
+def cross_two_lists(l1, l2):
+	"""
+	:rtype: list[tuple]
+	"""
+	return [(x, y) for x in l1 for y in l2]
+
+
+def cross_lists(*args):
+	"""
+	:rtype: list[tuple]
+	"""
+	if len(args) == 2:
+		return cross_two_lists(args[0], args[1])
+	elif len(args) > 2:
+		result = cross_lists(cross_two_lists(args[0], args[1]), *args[2:])
+		return [(x[0][0], x[0][1], *x[1:]) for x in result]
+	elif len(args) == 1 and isinstance(args[0], (list, tuple)):
+		return cross_lists(*args[0])

--- a/slytherin/get_size.py
+++ b/slytherin/get_size.py
@@ -1,4 +1,4 @@
-from collections import Mapping, Iterable
+from collections.abc import Mapping, Iterable
 from sys import getsizeof
 
 def deep_getsizeof(o, ids):

--- a/slytherin/immutability/ImmutableDictionary.py
+++ b/slytherin/immutability/ImmutableDictionary.py
@@ -9,9 +9,9 @@ except ImportError:  # python < 2.7
 iteritems = getattr(dict, 'iteritems', dict.items)  # py2-3 compatibility
 
 
-class ImmutableDictionary(collections.Mapping):
+class ImmutableDictionary(collections.abc.Mapping):
 	"""
-	An immutable wrapper around dictionaries that implements the complete :py:class:`collections.Mapping`
+	An immutable wrapper around dictionaries that implements the complete :py:class:`collections.abc.Mapping`
 	interface. It can be used as a drop-in replacement for dictionaries where immutability is desired.
 	"""
 


### PR DESCRIPTION
Fix for https://github.com/idin/slytherin/issues/1 .  This should work for Python 3.3 and newer, which includes all currently supported versions of Python (3.7+), but I haven't tested it against [linguistics](https://github.com/idin/linguistics) yet.

Signed-off-by: Scott Williams <scottwilliams@ucsb.edu>